### PR TITLE
Refactor: 예약 목록 조회 상점을 필터로 사용할 수 있게 변경

### DIFF
--- a/matjalalzz/src/main/java/shop/matjalalzz/global/config/SecurityConfig.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/config/SecurityConfig.java
@@ -74,8 +74,8 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, "/parties/{partyId}", "/parties").permitAll()
                     .requestMatchers("/admin/**").hasRole("ADMIN")
 
-                    .requestMatchers(HttpMethod.GET, "/shops/{shopId}/reservations").hasRole("OWNER")
-                    .requestMatchers(HttpMethod.PATCH,"/shops/{shopId}/reservations/**").hasRole("OWNER")
+                    .requestMatchers(HttpMethod.GET, "/reservations").hasRole("OWNER")
+                    .requestMatchers(HttpMethod.PATCH,"/reservations/{reservationId}/**").hasRole("OWNER")
 
                     .requestMatchers(HttpMethod.GET,"/shops/{shopId}").permitAll()
                     .requestMatchers(HttpMethod.GET, "/shops").permitAll()

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/api/ReservationController.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/api/ReservationController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -33,7 +34,7 @@ import shop.matjalalzz.reservation.entity.ReservationStatus;
 @RestController
 @RequiredArgsConstructor
 @Validated
-@RequestMapping()
+@RequestMapping
 @Tag(name = "예약 API", description = "예약 관련 API")
 public class ReservationController {
 
@@ -57,8 +58,11 @@ public class ReservationController {
         @RequestParam(required = false) Long shopId,
         @AuthenticationPrincipal PrincipalUser userInfo
     ) {
+
+
         ReservationListResponse response = reservationService.getReservations(shopId, filter,
-            cursor, userInfo.getId(),size);
+            userInfo.getId(), cursor, size);
+
 
         return BaseResponse.ok(response, BaseStatus.OK);
     }
@@ -88,6 +92,7 @@ public class ReservationController {
         @Valid @RequestBody CreateReservationRequest request,
         @AuthenticationPrincipal PrincipalUser userInfo
     ) {
+
         CreateReservationResponse response = reservationService.createReservation(userInfo.getId(),
             shopId, partyId, request);
 
@@ -105,10 +110,9 @@ public class ReservationController {
     @PatchMapping("/reservations/{reservationId}/confirm")
     @ResponseStatus(HttpStatus.OK)
     public BaseResponse<Void> confirmReservation(
-        @PathVariable Long shopId,
         @PathVariable Long reservationId,
         @AuthenticationPrincipal PrincipalUser principal) {
-        reservationService.confirmReservation(shopId, reservationId, principal.getId());
+        reservationService.confirmReservation(reservationId, principal.getId());
 
         return BaseResponse.ok(BaseStatus.OK);
     }
@@ -120,13 +124,12 @@ public class ReservationController {
             @ApiResponse(responseCode = "200", description = "예약 거절 성공"),
         }
     )
-    @PatchMapping("reservations/{reservationId}/cancel")
+    @PatchMapping("/reservations/{reservationId}/cancel")
     @ResponseStatus(HttpStatus.OK)
     public BaseResponse<Void> cancelReservation(
-        @PathVariable Long shopId,
         @PathVariable Long reservationId,
         @AuthenticationPrincipal PrincipalUser principal) {
-        reservationService.cancelReservation(shopId, reservationId, principal.getId());
+        reservationService.cancelReservation(reservationId, principal.getId());
 
         return BaseResponse.ok(BaseStatus.OK);
     }

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/api/ReservationController.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/api/ReservationController.java
@@ -33,7 +33,7 @@ import shop.matjalalzz.reservation.entity.ReservationStatus;
 @RestController
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/shops/{shopId}/reservations")
+@RequestMapping()
 @Tag(name = "예약 API", description = "예약 관련 API")
 public class ReservationController {
 
@@ -48,13 +48,13 @@ public class ReservationController {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 shopId")
         }
     )
-    @GetMapping
+    @GetMapping("/reservations")
     @ResponseStatus(HttpStatus.OK)
     public BaseResponse<ReservationListResponse> getReservations(
-        @PathVariable Long shopId,
         @RequestParam(required = false) ReservationStatus filter,
         @RequestParam(required = false) Long cursor,
         @RequestParam(defaultValue = "10") int size,
+        @RequestParam(required = false) Long shopId,
         @AuthenticationPrincipal PrincipalUser userInfo
     ) {
         ReservationListResponse response = reservationService.getReservations(shopId, filter,
@@ -80,7 +80,7 @@ public class ReservationController {
                 content = @Content(schema = @Schema(implementation = CreateReservationResponse.class)))
         }
     )
-    @PostMapping
+    @PostMapping("/shops/{shopId}/reservations")
     @ResponseStatus(HttpStatus.CREATED)
     public BaseResponse<CreateReservationResponse> createReservation(
         @PathVariable Long shopId,
@@ -102,7 +102,7 @@ public class ReservationController {
             @ApiResponse(responseCode = "200", description = "예약 수락 성공"),
         }
     )
-    @PatchMapping("/{reservationId}/confirm")
+    @PatchMapping("/reservations/{reservationId}/confirm")
     @ResponseStatus(HttpStatus.OK)
     public BaseResponse<Void> confirmReservation(
         @PathVariable Long shopId,
@@ -120,7 +120,7 @@ public class ReservationController {
             @ApiResponse(responseCode = "200", description = "예약 거절 성공"),
         }
     )
-    @PatchMapping("/{reservationId}/cancel")
+    @PatchMapping("reservations/{reservationId}/cancel")
     @ResponseStatus(HttpStatus.OK)
     public BaseResponse<Void> cancelReservation(
         @PathVariable Long shopId,

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/app/ReservationTerminator.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/app/ReservationTerminator.java
@@ -1,0 +1,20 @@
+package shop.matjalalzz.reservation.app;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationTerminator {
+
+    private final ReservationService reservationService;
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void terminateReservations() {
+        int count = reservationService.terminateExpiredReservations();
+        log.info("[TERMINATE 배치] 처리된 예약 수 = {}", count);
+    }
+}

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepository.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepository.java
@@ -38,7 +38,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         ORDER BY r.id DESC
         """)
     Slice<Reservation> findByShopIdsWithFilterAndCursor(
-        @Param("shopId") List<Long> shopIds,
+        @Param("shopIds") List<Long> shopIds,
         @Param("status") ReservationStatus status,
         @Param("cursor") Long cursor,
         Pageable pageable

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepository.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepository.java
@@ -2,6 +2,7 @@ package shop.matjalalzz.reservation.dao;
 
 import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -24,6 +25,20 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         """)
     Slice<Reservation> findByShopIdWithFilterAndCursor(
         @Param("shopId") Long shopId,
+        @Param("status") ReservationStatus status,
+        @Param("cursor") Long cursor,
+        Pageable pageable
+    );
+
+    @Query("""
+        SELECT r FROM Reservation r
+        WHERE r.shop.id IN :shopIds
+          AND (:status IS NULL OR r.status = :status)
+          AND (:cursor IS NULL OR r.id < :cursor)
+        ORDER BY r.id DESC
+        """)
+    Slice<Reservation> findByShopIdsWithFilterAndCursor(
+        @Param("shopId") List<Long> shopIds,
         @Param("status") ReservationStatus status,
         @Param("cursor") Long cursor,
         Pageable pageable
@@ -63,4 +78,13 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         @Param("userId") Long userId,
         @Param("cursor") Long cursor,
         Pageable pageable);
+
+    @Query("""
+    SELECT r FROM Reservation r
+    WHERE r.status IN :statuses
+      AND r.reservedAt <= :threshold
+        """)
+    List<Reservation> findAllByStatusInAndReservedAtBefore(
+        @Param("statuses") List<ReservationStatus> statuses,
+        @Param("threshold") LocalDateTime threshold);
 }

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/dto/ReservationListResponse.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/dto/ReservationListResponse.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
+import shop.matjalalzz.reservation.entity.ReservationStatus;
 
 @Builder
 @Schema(description = "예약 목록 응답 DTO")
@@ -34,7 +35,10 @@ public record ReservationListResponse(
         int headCount,
 
         @Schema(description = "예약자 전화번호", example = "010-1234-5678")
-        String phoneNumber
+        String phoneNumber,
+
+        @Schema(description = "예약자 전화번호", example = "010-1234-5678")
+        ReservationStatus status
 
     ) {
 

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/mapper/ReservationMapper.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/mapper/ReservationMapper.java
@@ -63,6 +63,7 @@ public class ReservationMapper {
                     .headCount(res.getHeadCount())
                 .phoneNumber(
                     res.getUser().getPhoneNumber())           // ← N+1 가능성 있음, fetch join 필요
+                .status(res.getStatus())
                 .build())
             .toList();
     }

--- a/matjalalzz/src/main/java/shop/matjalalzz/shop/app/ShopService.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/shop/app/ShopService.java
@@ -166,6 +166,6 @@ public class ShopService {
 
     @Transactional(readOnly = true)
     public List<Shop> findByOwnerId(Long ownerId) {
-        return shopRepository.findShopsById(ownerId);
+        return shopRepository.findByUserId(ownerId);
     }
 }

--- a/matjalalzz/src/main/java/shop/matjalalzz/shop/app/ShopService.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/shop/app/ShopService.java
@@ -163,4 +163,9 @@ public class ShopService {
         //shopRepository.(latitude,longitude,radius,foodCategories,sort,cursor,size+1);
 
     }
+
+    @Transactional(readOnly = true)
+    public List<Shop> findByOwnerId(Long ownerId) {
+        return shopRepository.findShopsById(ownerId);
+    }
 }

--- a/matjalalzz/src/main/java/shop/matjalalzz/shop/dao/ShopRepository.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/shop/dao/ShopRepository.java
@@ -17,7 +17,7 @@ public interface ShopRepository extends JpaRepository<Shop, Long> {
     
     List<Shop> findByUser(User user);
 
-    List<Shop> findShopsById(Long id);
+    List<Shop> findByUserId(Long id);
 
 //
 //

--- a/matjalalzz/src/main/java/shop/matjalalzz/shop/dao/ShopRepository.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/shop/dao/ShopRepository.java
@@ -2,6 +2,7 @@ package shop.matjalalzz.shop.dao;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +17,7 @@ public interface ShopRepository extends JpaRepository<Shop, Long> {
     
     List<Shop> findByUser(User user);
 
+    List<Shop> findShopsById(Long id);
 
 //
 //

--- a/matjalalzz/src/test/java/shop/matjalalzz/reservation/app/ReservationTerminatorTest.java
+++ b/matjalalzz/src/test/java/shop/matjalalzz/reservation/app/ReservationTerminatorTest.java
@@ -1,0 +1,82 @@
+package shop.matjalalzz.reservation.app;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import shop.matjalalzz.reservation.dao.ReservationRepository;
+import shop.matjalalzz.reservation.entity.Reservation;
+import shop.matjalalzz.reservation.entity.ReservationStatus;
+import shop.matjalalzz.shop.dao.ShopRepository;
+import shop.matjalalzz.shop.entity.Shop;
+import shop.matjalalzz.user.dao.UserRepository;
+import shop.matjalalzz.user.entity.User;
+import shop.matjalalzz.util.TestUtil;
+
+@SpringBootTest
+@Transactional
+@DisplayName("예약 TERMINATE 배치 테스트")
+class ReservationTerminatorTest {
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ShopRepository shopRepository;
+
+    @Test
+    @DisplayName("reservedAt + 1일이 지난 예약은 TERMINATED 처리된다.")
+    void terminateExpiredReservations() {
+        // given
+        User user = userRepository.save(TestUtil.createUser());
+        Shop shop = shopRepository.save(TestUtil.createShop(user));
+
+        // TERMINATE 대상
+        Reservation expired1 = reservationRepository.save(
+            TestUtil.createReservation(shop, user, null, LocalDateTime.now().minusDays(2))
+        );
+
+        Reservation expired2 = reservationRepository.save(
+            TestUtil.createReservation(shop, user, null, LocalDateTime.now().minusDays(1).minusMinutes(5))
+        );
+
+        // TERMINATE 대상 아님
+        Reservation valid = reservationRepository.save(
+            TestUtil.createReservation(shop, user, null, LocalDateTime.now().minusHours(23))
+        );
+
+        // TERMINATED 상태로 이미 있는 예약
+        Reservation alreadyTerminated = reservationRepository.save(
+            TestUtil.createReservation(shop, user, null, LocalDateTime.now().minusDays(5))
+        );
+        alreadyTerminated.changeStatus(ReservationStatus.TERMINATED); // 상태 직접 설정
+
+        // when
+        int result = reservationService.terminateExpiredReservations();
+
+        // then
+        assertThat(result).isEqualTo(2);
+
+        Reservation check1 = reservationRepository.findById(expired1.getId()).orElseThrow();
+        Reservation check2 = reservationRepository.findById(expired2.getId()).orElseThrow();
+        Reservation check3 = reservationRepository.findById(valid.getId()).orElseThrow();
+        Reservation check4 = reservationRepository.findById(alreadyTerminated.getId()).orElseThrow();
+
+        assertThat(check1.getStatus()).isEqualTo(ReservationStatus.TERMINATED);
+        assertThat(check2.getStatus()).isEqualTo(ReservationStatus.TERMINATED);
+        assertThat(check3.getStatus()).isEqualTo(ReservationStatus.PENDING); // 유지
+        assertThat(check4.getStatus()).isEqualTo(ReservationStatus.TERMINATED); // 유지
+    }
+}
+

--- a/matjalalzz/src/test/java/shop/matjalalzz/review/app/ReviewServiceTest.java
+++ b/matjalalzz/src/test/java/shop/matjalalzz/review/app/ReviewServiceTest.java
@@ -372,16 +372,16 @@ class ReviewServiceTest {
 
             // then
             assertThat(response).isNotNull();
-            assertThat(response.reviews()).hasSize(2);
-            assertThat(response.reviews().getFirst().reviewId()).isEqualTo(1L);
-            assertThat(response.reviews().getFirst().content()).isEqualTo("맛있어요!");
-            assertThat(response.reviews().get(0).rating()).isEqualTo(4.5);
-            assertThat(response.reviews().get(0).userNickname()).isEqualTo("테스터1");
+            assertThat(response.content()).hasSize(2);
+            assertThat(response.content().getFirst().reviewId()).isEqualTo(1L);
+            assertThat(response.content().getFirst().content()).isEqualTo("맛있어요!");
+            assertThat(response.content().get(0).rating()).isEqualTo(4.5);
+            assertThat(response.content().get(0).userNickname()).isEqualTo("테스터1");
 
-            assertThat(response.reviews().get(1).reviewId()).isEqualTo(2L);
-            assertThat(response.reviews().get(1).content()).isEqualTo("서비스가 좋아요!");
-            assertThat(response.reviews().get(1).rating()).isEqualTo(5.0);
-            assertThat(response.reviews().get(1).userNickname()).isEqualTo("테스터2");
+            assertThat(response.content().get(1).reviewId()).isEqualTo(2L);
+            assertThat(response.content().get(1).content()).isEqualTo("서비스가 좋아요!");
+            assertThat(response.content().get(1).rating()).isEqualTo(5.0);
+            assertThat(response.content().get(1).userNickname()).isEqualTo("테스터2");
 
             // 다음 페이지가 없으므로 nextCursor는 null
             assertThat(response.nextCursor()).isNull();
@@ -427,7 +427,7 @@ class ReviewServiceTest {
 
             // then
             assertThat(response).isNotNull();
-            assertThat(response.reviews()).hasSize(2);
+            assertThat(response.content()).hasSize(2);
             // 다음 페이지가 있으므로 nextCursor는 마지막 리뷰의 ID
             assertThat(response.nextCursor()).isEqualTo(2L);
         }
@@ -449,7 +449,7 @@ class ReviewServiceTest {
 
             // then
             assertThat(response).isNotNull();
-            assertThat(response.reviews()).isEmpty();
+            assertThat(response.content()).isEmpty();
             assertThat(response.nextCursor()).isNull();
         }
 

--- a/matjalalzz/src/test/java/shop/matjalalzz/util/TestUtil.java
+++ b/matjalalzz/src/test/java/shop/matjalalzz/util/TestUtil.java
@@ -49,7 +49,6 @@ public class TestUtil {
             .reservationFee(1000)
             .openTime(LocalTime.of(10, 0))
             .closeTime(LocalTime.of(22, 0))
-            .user(owner)
             .build();
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- #61 

## 💡 구현 내용 요약
- 기존 PathVariable로 받던 ShopId를 Parameter로 받을 수 있게 수정

## ✅ 작업 상세 내용
- 기존 PathVariable로 받던 ShopId를 Parameter로 받을 수 있게 수정
- 예약 목록 조회할 때, status를 보낼 수 있도록 추가
- 테스트 진행
- 예약 스케줄링 임시 구현

## 🧪 check list
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함
- [x] merge할 브랜치의 위치를 확인함

## 📎 기타 참고 사항
- 
