### PR TITLE
Feat: 토스 서버 통신 실패시 에러 핸들러 구현

### DIFF
--- a/matjalalzz/src/main/java/shop/matjalalzz/global/exception/domain/ErrorCode.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/exception/domain/ErrorCode.java
@@ -76,6 +76,9 @@ public enum ErrorCode {
     NOT_MATCH_ORDER(HttpStatus.BAD_REQUEST, "주문 정보가 일치하지 않습니다."),
     INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "이미 주문이 완료되었거나 취소된 건입니다."),
 
+    //502
+    TOSS_FEIGN_FAIL(HttpStatus.BAD_GATEWAY, "토스 서버와의 통신에 실패하였습니다."),
+
     /**
      * party
      */
@@ -121,7 +124,6 @@ public enum ErrorCode {
      */
     // 여러 이미지 저장 시 하나의 이미지라도 저장에 실패하면 안됨
     IMAGE_SAVE_FAILED(HttpStatus.BAD_REQUEST, "이미지 저장에 실패하였습니다."),
-
 
     /**
      * image

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/exception/handler/GlobalExceptionHandler.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/exception/handler/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package shop.matjalalzz.global.exception.handler;
 
 
+import feign.FeignException;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -14,6 +16,7 @@ import shop.matjalalzz.global.exception.OAuth2Exception;
 import shop.matjalalzz.global.exception.domain.ErrorCode;
 import shop.matjalalzz.global.exception.dto.ErrorResponse;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -84,6 +87,23 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleOptimisticLockException(
         ObjectOptimisticLockingFailureException e, HttpServletRequest request) {
         ErrorCode code = ErrorCode.LOCK_FAILURE;
+
+        String path = request.getMethod() + " " + request.getRequestURI();
+
+        return ResponseEntity.status(code.getStatus()).body(ErrorResponse.builder()
+            .status(code.getStatus().value())
+            .code(code.name())
+            .message(code.getMessage())
+            .path(path)
+            .build());
+    }
+
+    @ExceptionHandler(FeignException.class)
+    public ResponseEntity<ErrorResponse> handleFeignException(
+        FeignException e, HttpServletRequest request
+    ) {
+        log.error("토스 서버와의 통신에 실패하였습니다.");
+        ErrorCode code = ErrorCode.TOSS_FEIGN_FAIL;
 
         String path = request.getMethod() + " " + request.getRequestURI();
 

--- a/matjalalzz/src/main/java/shop/matjalalzz/tosspay/entity/Order.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/tosspay/entity/Order.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import shop.matjalalzz.global.common.BaseEntity;
 import shop.matjalalzz.user.entity.User;
 
@@ -21,6 +22,7 @@ import shop.matjalalzz.user.entity.User;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "orders")
+@SQLRestriction("deleted = false")
 public class Order extends BaseEntity {
 
     @Id


### PR DESCRIPTION
## 📌 관련 이슈
- #84 

## ✅ 작업 상세 내용
- Order 엔티티에 @SQLRestriction("deleted = false") 추가
- 토스 서버와 통신이 실패해서 FeignException이 터졌을 때 에러 핸들러 추가

## 🧪 check list
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함
- [x] merge할 브랜치의 위치를 확인함

## 📎 기타 참고 사항
- 
