### PR TITLE
Refactor: User, Token 성능 개선

### DIFF
--- a/matjalalzz/build.gradle
+++ b/matjalalzz/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'idea'
 }
 
 dependencyManagement {
@@ -28,6 +29,35 @@ configurations {
 repositories {
     mavenCentral()
 }
+
+
+// QueryDSL 설정
+def qdslMainDir = "$buildDir/generated/querydsl/main"
+def qdslTestDir = "$buildDir/generated/querydsl/test"
+
+def queryDslVersion = "7.0" // 25년 7월 기준 가장 최신
+def querydslSrcDir  = layout.buildDirectory.dir("generated/querydsl").get().asFile // build/generated/querydsl
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslSrcDir))
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs += qdslMainDir
+        }
+    }
+    test {
+        java {
+            srcDirs += qdslTestDir
+        }
+    }
+}
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+//
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -68,9 +98,20 @@ dependencies {
     implementation("net.logstash.logback:logstash-logback-encoder:7.4")
 
 
+
     implementation('net.dv8tion:JDA:5.0.0-beta.20') {
         exclude module: 'opus-java'
         exclude module: 'tink'}
+
+    implementation "net.ttddyy:datasource-proxy:1.10"
+
+    implementation "com.github.gavlyukovskiy:datasource-proxy-spring-boot-starter:1.9.2"
+
+    //Querydsl 추가
+    implementation("io.github.openfeign.querydsl:querydsl-core:${queryDslVersion}")
+    implementation("io.github.openfeign.querydsl:querydsl-jpa:$queryDslVersion")
+    annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:$queryDslVersion:jpa")
+
 }
 
 tasks.named('test') {

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/aop/QueryPerfAspect.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/aop/QueryPerfAspect.java
@@ -1,0 +1,51 @@
+package shop.matjalalzz.global.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import static shop.matjalalzz.global.config.DsProxyLoggingConfig.JDBC_NS;
+
+
+@Slf4j
+@Aspect
+@Component
+public class QueryPerfAspect {
+
+    // 측정 범위: repository와 usecase
+    private static final ThreadLocal<Integer> DEPTH = ThreadLocal.withInitial(() -> 0);
+
+    @Around("execution(* shop.matjalalzz..repository..*(..)) || " +
+        "execution(* shop.matjalalzz..dao..*(..)) || " +
+        "execution(* shop.matjalalzz..usecase..*(..))")
+    public Object measure(ProceedingJoinPoint pjp) throws Throwable {
+        int depth = DEPTH.get();
+        boolean outer = depth == 0;
+
+        if (outer) {
+            JDBC_NS.set(0L); // 바깥 레벨에서만 JDBC 누적 초기화
+        }
+        DEPTH.set(depth + 1);
+
+        long t0 = System.nanoTime();
+        try {
+            return pjp.proceed();
+        } finally {
+            int cur = DEPTH.get() - 1;
+            DEPTH.set(cur);
+
+            if (cur == 0) { // 바깥 레벨에서만 로그 + ThreadLocal 정리
+                double total = (System.nanoTime() - t0) / 1_000_000.0;
+                double jdbc = JDBC_NS.get() / 1_000_000.0;
+                double overhead = Math.max(0, total - jdbc);
+
+                String sig = ((MethodSignature) pjp.getSignature()).toShortString();
+                log.info(String.format("[PERF] %s | total=%.3f ms | jdbc=%.3f ms | overhead=%.3f ms", sig, total, jdbc, overhead));
+
+                JDBC_NS.remove();
+                DEPTH.remove();
+            }
+        }
+    }
+}

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/config/DsProxyLoggingConfig.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/config/DsProxyLoggingConfig.java
@@ -1,0 +1,46 @@
+package shop.matjalalzz.global.config;
+
+
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import net.ttddyy.dsproxy.ExecutionInfo;
+import net.ttddyy.dsproxy.QueryInfo;
+import net.ttddyy.dsproxy.listener.QueryExecutionListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class DsProxyLoggingConfig {
+
+    // JDBC 누적 시간 저장용 ThreadLocal
+
+    // JDBC 누적(ns)
+    public static final ThreadLocal<Long> JDBC_NS = ThreadLocal.withInitial(() -> 0L);
+    // 쿼리 단위 시작(ns)
+    private static final ThreadLocal<Long> START_NS = new ThreadLocal<>();
+
+    @Bean
+    public QueryExecutionListener queryExecutionListener() {
+        return new QueryExecutionListener() {
+            @Override
+            public void beforeQuery(ExecutionInfo ei, List<QueryInfo> qi) {
+                START_NS.set(System.nanoTime()); // 나노초 시작
+            }
+
+            @Override
+            public void afterQuery(ExecutionInfo ei, List<QueryInfo> qi) {
+                long start = START_NS.get() != null ? START_NS.get() : System.nanoTime();
+                START_NS.remove();
+
+                long ns = System.nanoTime() - start;          // 나노초 경과
+                JDBC_NS.set(JDBC_NS.get() + ns);              // 누적
+
+                String sql = qi.isEmpty() ? "" : qi.get(0).getQuery();
+                String oneLine = sql == null ? "" : sql.replaceAll("\\s+"," ").trim();
+                double ms = ns / 1_000_000.0;
+                log.info(String.format("[SQL] %.3f ms | %s", ms, oneLine));
+            }
+        };
+    }
+}

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/config/QueryDSLConfig.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/config/QueryDSLConfig.java
@@ -1,0 +1,20 @@
+package shop.matjalalzz.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+
+}

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/handler/OAuth2SuccessHandler.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/handler/OAuth2SuccessHandler.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 import shop.matjalalzz.global.security.PrincipalUser;
 import shop.matjalalzz.global.security.jwt.app.TokenService;
-import shop.matjalalzz.global.security.jwt.dto.LoginTokenResponseDto;
+import shop.matjalalzz.global.security.jwt.dto.LoginTokenResponse;
 import shop.matjalalzz.global.util.CookieUtils;
 
 @Slf4j
@@ -34,7 +34,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         PrincipalUser userInfo = (PrincipalUser) authentication.getPrincipal();
 
-        LoginTokenResponseDto dto = tokenService.oauthLogin(userInfo.getUsername());
+        LoginTokenResponse dto = tokenService.oauthLogin(userInfo.getUsername());
 
         CookieUtils.setRefreshTokenCookie(response, dto.refreshToken(), refreshTokenValidityTime);
 

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/api/TokenController.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/api/TokenController.java
@@ -1,30 +1,26 @@
 package shop.matjalalzz.global.security.jwt.api;
 
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
-import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import shop.matjalalzz.global.common.BaseResponse;
 import shop.matjalalzz.global.common.BaseStatus;
 import shop.matjalalzz.global.security.PrincipalUser;
 import shop.matjalalzz.global.security.jwt.app.TokenService;
-import shop.matjalalzz.global.security.jwt.dto.AccessTokenResponseDto;
+import shop.matjalalzz.global.security.jwt.dto.AccessTokenResponse;
 
 @Tag(name = "사용자 API", description = "사용자 관련 API")
 @RestController
@@ -43,7 +39,7 @@ public class TokenController {
     )
     @PostMapping("/reissue-token")
     @ResponseStatus(HttpStatus.CREATED)
-    public BaseResponse<AccessTokenResponseDto> refreshToken(
+    public BaseResponse<AccessTokenResponse> refreshToken(
         @Parameter(hidden = true)
         @CookieValue(name = "refreshToken") String refreshToken) {
         return BaseResponse.ok(tokenService.refreshAccessToken(refreshToken), BaseStatus.OK);

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/app/TokenService.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/app/TokenService.java
@@ -10,7 +10,7 @@ import shop.matjalalzz.global.exception.BusinessException;
 import shop.matjalalzz.global.exception.domain.ErrorCode;
 import shop.matjalalzz.global.security.jwt.dao.RefreshTokenRepository;
 import shop.matjalalzz.global.security.jwt.dto.AccessTokenResponse;
-import shop.matjalalzz.global.security.jwt.dto.AuthUserInfoDto;
+import shop.matjalalzz.global.security.jwt.dto.AuthUserView;
 import shop.matjalalzz.global.security.jwt.dto.LoginTokenResponse;
 import shop.matjalalzz.global.security.jwt.entity.RefreshToken;
 import shop.matjalalzz.global.security.jwt.mapper.TokenMapper;
@@ -68,11 +68,16 @@ public class TokenService {
         }
 
         Long userId = tokenProvider.parseRefreshToken(refreshToken);
-        AuthUserInfoDto info = refreshTokenRepository.findByUserIdWithUser(userId)
+        AuthUserView info = refreshTokenRepository.findByUserIdWithUser(userId)
             .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN));
 
+        if (!refreshToken.equals(info.getRefreshToken())) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
         // 새로운 액세스 토큰 발급
-        String newAccessToken = tokenProvider.issueAccessToken(userId, info.role(), info.email());
+        String newAccessToken = tokenProvider.issueAccessToken(userId, info.getRole(),
+            info.getEmail());
         return new AccessTokenResponse(newAccessToken);
     }
 

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/app/TokenService.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/app/TokenService.java
@@ -3,15 +3,14 @@ package shop.matjalalzz.global.security.jwt.app;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.matjalalzz.global.exception.BusinessException;
 import shop.matjalalzz.global.exception.domain.ErrorCode;
 import shop.matjalalzz.global.security.jwt.dao.RefreshTokenRepository;
-import shop.matjalalzz.global.security.jwt.dto.AccessTokenResponseDto;
-import shop.matjalalzz.global.security.jwt.dto.LoginTokenResponseDto;
-import shop.matjalalzz.global.security.jwt.dto.TokenBodyDto;
+import shop.matjalalzz.global.security.jwt.dto.AccessTokenResponse;
+import shop.matjalalzz.global.security.jwt.dto.AuthUserInfoDto;
+import shop.matjalalzz.global.security.jwt.dto.LoginTokenResponse;
 import shop.matjalalzz.global.security.jwt.entity.RefreshToken;
 import shop.matjalalzz.global.security.jwt.mapper.TokenMapper;
 import shop.matjalalzz.global.util.CookieUtils;
@@ -28,7 +27,7 @@ public class TokenService {
     private final TokenProvider tokenProvider;
 
     @Transactional
-    public LoginTokenResponseDto oauthLogin(String email) {
+    public LoginTokenResponse oauthLogin(String email) {
         User found = userRepository.findByEmail(email)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
@@ -51,20 +50,18 @@ public class TokenService {
     }
 
     @Transactional(readOnly = true)
-    public AccessTokenResponseDto refreshAccessToken(String refreshToken) {
+    public AccessTokenResponse refreshAccessToken(String refreshToken) {
         if (!tokenProvider.validate(refreshToken)) {
             throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         Long userId = tokenProvider.parseRefreshToken(refreshToken);
-        RefreshToken token = refreshTokenRepository.findByUserIdWithUser(userId)
+        AuthUserInfoDto info = refreshTokenRepository.findByUserIdWithUser(userId)
             .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN));
-        User user = token.getUser();
 
         // 새로운 액세스 토큰 발급
-        String newAccessToken = tokenProvider.issueAccessToken(user.getId(), user.getRole(),
-            user.getEmail());
-        return new AccessTokenResponseDto(newAccessToken);
+        String newAccessToken = tokenProvider.issueAccessToken(userId, info.role(), info.email());
+        return new AccessTokenResponse(newAccessToken);
     }
 
     @Transactional

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dao/RefreshTokenRepository.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dao/RefreshTokenRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import shop.matjalalzz.global.security.jwt.dto.AuthUserInfoDto;
+import shop.matjalalzz.global.security.jwt.dto.AuthUserView;
 import shop.matjalalzz.global.security.jwt.entity.RefreshToken;
 import shop.matjalalzz.user.entity.User;
 
@@ -15,12 +15,12 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByUser(User user);
 
     @Query("""
-        SELECT new shop.matjalalzz.global.security.jwt.dto.AuthUserInfoDto(u.role, u.email)
+        SELECT rt.refreshToken as refreshToken, u.role as role, u.email as email
         FROM RefreshToken rt
             JOIN rt.user u
         WHERE rt.user.id = :userId
         """)
-    Optional<AuthUserInfoDto> findByUserIdWithUser(@Param("userId") Long userId);
+    Optional<AuthUserView> findByUserIdWithUser(@Param("userId") Long userId);
 
     @Modifying
     @Query(value = """

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dao/RefreshTokenRepository.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dao/RefreshTokenRepository.java
@@ -3,6 +3,7 @@ package shop.matjalalzz.global.security.jwt.dao;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import shop.matjalalzz.global.security.jwt.dto.AuthUserInfoDto;
@@ -13,14 +14,20 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     Optional<RefreshToken> findByUser(User user);
 
-//    @Query("SELECT rt FROM RefreshToken rt JOIN FETCH rt.user u WHERE u.id = :userId")
-//    Optional<RefreshToken> findByUserIdWithUser(@Param("userId") Long userId);
-
     @Query("""
         SELECT new shop.matjalalzz.global.security.jwt.dto.AuthUserInfoDto(u.role, u.email)
         FROM RefreshToken rt
             JOIN rt.user u
         WHERE rt.user.id = :userId
-    """)
+        """)
     Optional<AuthUserInfoDto> findByUserIdWithUser(@Param("userId") Long userId);
+
+    @Modifying
+    @Query(value = """
+        INSERT INTO refresh_token (refresh_token, user_id)
+        VALUES (:refreshToken, :userId)
+        ON DUPLICATE KEY UPDATE
+            refresh_token = :refreshToken
+        """, nativeQuery = true)
+    void upsertByUserId(@Param("userId") Long userId, @Param("refreshToken") String refreshToken);
 }

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dao/RefreshTokenRepository.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dao/RefreshTokenRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import shop.matjalalzz.global.security.jwt.dto.AuthUserInfoDto;
 import shop.matjalalzz.global.security.jwt.entity.RefreshToken;
 import shop.matjalalzz.user.entity.User;
 
@@ -12,7 +13,14 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     Optional<RefreshToken> findByUser(User user);
 
-    @Query("SELECT rt FROM RefreshToken rt JOIN FETCH rt.user u WHERE u.id = :userId")
-    Optional<RefreshToken> findByUserIdWithUser(@Param("userId") Long userId);
+//    @Query("SELECT rt FROM RefreshToken rt JOIN FETCH rt.user u WHERE u.id = :userId")
+//    Optional<RefreshToken> findByUserIdWithUser(@Param("userId") Long userId);
 
+    @Query("""
+        SELECT new shop.matjalalzz.global.security.jwt.dto.AuthUserInfoDto(u.role, u.email)
+        FROM RefreshToken rt
+            JOIN rt.user u
+        WHERE rt.user.id = :userId
+    """)
+    Optional<AuthUserInfoDto> findByUserIdWithUser(@Param("userId") Long userId);
 }

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/AccessTokenResponse.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/AccessTokenResponse.java
@@ -1,0 +1,5 @@
+package shop.matjalalzz.global.security.jwt.dto;
+
+public record AccessTokenResponse(String accessToken) {
+
+}

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/AccessTokenResponseDto.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/AccessTokenResponseDto.java
@@ -1,5 +1,0 @@
-package shop.matjalalzz.global.security.jwt.dto;
-
-public record AccessTokenResponseDto(String accessToken) {
-
-}

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/AuthUserInfoDto.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/AuthUserInfoDto.java
@@ -1,7 +1,0 @@
-package shop.matjalalzz.global.security.jwt.dto;
-
-import shop.matjalalzz.user.entity.enums.Role;
-
-public record AuthUserInfoDto(Role role, String email) {
-
-}

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/AuthUserInfoDto.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/AuthUserInfoDto.java
@@ -1,0 +1,7 @@
+package shop.matjalalzz.global.security.jwt.dto;
+
+import shop.matjalalzz.user.entity.enums.Role;
+
+public record AuthUserInfoDto(Role role, String email) {
+
+}

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/AuthUserView.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/AuthUserView.java
@@ -1,0 +1,9 @@
+package shop.matjalalzz.global.security.jwt.dto;
+
+import shop.matjalalzz.user.entity.enums.Role;
+
+public interface AuthUserView {
+    String getRefreshToken();
+    Role getRole();
+    String getEmail();
+}

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/LoginTokenResponse.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/LoginTokenResponse.java
@@ -3,7 +3,7 @@ package shop.matjalalzz.global.security.jwt.dto;
 import lombok.Builder;
 
 @Builder
-public record LoginTokenResponseDto(
+public record LoginTokenResponse(
     String accessToken,
     String refreshToken) {
 

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/RefreshTokenRequestDto.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/dto/RefreshTokenRequestDto.java
@@ -1,5 +1,0 @@
-package shop.matjalalzz.global.security.jwt.dto;
-
-public record RefreshTokenRequestDto(String refreshToken) {
-
-}

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/entity/RefreshToken.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/entity/RefreshToken.java
@@ -6,10 +6,10 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +18,7 @@ import shop.matjalalzz.user.entity.User;
 
 @Getter
 @Entity
-@Table(name = "refresh_tokens", indexes = @Index(name = "idx_user_id", columnList = "user_id"))
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = "user_id"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshToken {
 
@@ -28,6 +28,7 @@ public class RefreshToken {
 
     @Column(nullable = false, length = 500)
     private String refreshToken;
+
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/mapper/TokenMapper.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/mapper/TokenMapper.java
@@ -7,12 +7,6 @@ import shop.matjalalzz.user.entity.User;
 import shop.matjalalzz.user.entity.enums.Role;
 
 public class TokenMapper {
-    public static RefreshToken toRefreshToken(String refreshToken, User user) {
-        return RefreshToken.builder()
-                .refreshToken(refreshToken)
-                .user(user)
-                .build();
-    }
 
     public static TokenBodyDto toTokenBodyDto(Long userId, String email, Role role) {
         return TokenBodyDto.builder()

--- a/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/mapper/TokenMapper.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/global/security/jwt/mapper/TokenMapper.java
@@ -1,6 +1,6 @@
 package shop.matjalalzz.global.security.jwt.mapper;
 
-import shop.matjalalzz.global.security.jwt.dto.LoginTokenResponseDto;
+import shop.matjalalzz.global.security.jwt.dto.LoginTokenResponse;
 import shop.matjalalzz.global.security.jwt.dto.TokenBodyDto;
 import shop.matjalalzz.global.security.jwt.entity.RefreshToken;
 import shop.matjalalzz.user.entity.User;
@@ -22,9 +22,9 @@ public class TokenMapper {
                 .build();
     }
 
-    public static LoginTokenResponseDto toLoginTokenResponseDto(
+    public static LoginTokenResponse toLoginTokenResponseDto(
             String accessToken, String refreshToken) {
-        return LoginTokenResponseDto.builder()
+        return LoginTokenResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();

--- a/matjalalzz/src/main/java/shop/matjalalzz/image/app/ImageService.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/image/app/ImageService.java
@@ -1,10 +1,12 @@
 package shop.matjalalzz.image.app;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.matjalalzz.image.dao.ImageRepository;
+import shop.matjalalzz.image.dto.ReviewImageView;
 
 @Service
 @RequiredArgsConstructor
@@ -20,5 +22,10 @@ public class ImageService {
         return imageRepository.findByShopIdAndImageIndex(shopId, 0)
             .map(image -> BASE_URL + image.getS3Key())
             .orElse(null);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReviewImageView> findReviewImages(List<Long> reviewIds) {
+        return imageRepository.findImageKeyByReviewIds(reviewIds);
     }
 }

--- a/matjalalzz/src/main/java/shop/matjalalzz/image/dao/ImageRepository.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/image/dao/ImageRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import shop.matjalalzz.image.dto.ReviewImageView;
 import shop.matjalalzz.image.entity.Image;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
@@ -23,5 +24,11 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
     Optional<Image> findByShopIdAndImageIndex(Long shopId, long imageIndex);
 
-
+    @Query("""
+        SELECT i.reviewId AS reviewId, i.s3Key AS s3Key
+        FROM Image i
+        WHERE i.reviewId in :reviewIds
+        ORDER BY i.reviewId ASC, i.imageIndex ASC
+        """)
+    List<ReviewImageView> findImageKeyByReviewIds(@Param("reviewIds") List<Long> reviewIds);
 }

--- a/matjalalzz/src/main/java/shop/matjalalzz/image/dto/ReviewImageView.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/image/dto/ReviewImageView.java
@@ -1,0 +1,6 @@
+package shop.matjalalzz.image.dto;
+
+public interface ReviewImageView {
+    long getReviewId();
+    String getS3Key();
+}

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/app/ReservationFacade.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/app/ReservationFacade.java
@@ -122,11 +122,7 @@ public class ReservationFacade {
 
     @Transactional(readOnly = true)
     public MyReservationPageResponse findMyReservationPage(Long userId, Long cursor, int size) {
-//        Slice<MyReservationResponse> reservations = reservationService.findByUserIdAndCursor(
-//            userId, cursor,
-//            PageRequest.of(0, size));
-
-        Slice<MyReservationResponse> reservations = reservationService.findByUserIdAndCursorQdsl(
+        Slice<MyReservationResponse> reservations = reservationService.findByUserIdAndCursor(
             userId, cursor,
             PageRequest.of(0, size));
 

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/app/ReservationService.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/app/ReservationService.java
@@ -13,6 +13,7 @@ import shop.matjalalzz.global.exception.domain.ErrorCode;
 import shop.matjalalzz.party.entity.Party;
 import shop.matjalalzz.reservation.dao.ReservationRepository;
 import shop.matjalalzz.reservation.dto.MyReservationResponse;
+import shop.matjalalzz.reservation.dto.MyReservationView;
 import shop.matjalalzz.reservation.dto.ReservationSummaryDto;
 import shop.matjalalzz.reservation.entity.Reservation;
 import shop.matjalalzz.reservation.entity.ReservationStatus;
@@ -51,7 +52,10 @@ public class ReservationService {
     @Transactional(readOnly = true)
     public Slice<MyReservationResponse> findByUserIdAndCursor(
         Long userId, Long cursor, Pageable pageable) {
-        return reservationRepository.findByUserIdAndCursor(userId, cursor, pageable);
+        Slice<MyReservationView> views = reservationRepository.findByUserIdAndCursor(
+            userId, cursor, pageable);
+
+        return views.map(ReservationMapper::toMyReservationResponse);
     }
 
     @Transactional(readOnly = true)

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/app/ReservationService.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/app/ReservationService.java
@@ -55,12 +55,6 @@ public class ReservationService {
     }
 
     @Transactional(readOnly = true)
-    public Slice<MyReservationResponse> findByUserIdAndCursorQdsl(
-        Long userId, Long cursor, Pageable pageable) {
-        return reservationRepository.findByUserIdAndCursorQdsl(userId, cursor, pageable);
-    }
-
-    @Transactional(readOnly = true)
     public Slice<Reservation> findByShopIdsWithFilterAndCursor(
         List<Long> shopIds, ReservationStatus status, Long cursor, Pageable pageable) {
         return reservationRepository.findByShopIdsWithFilterAndCursor(

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/app/ReservationService.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/app/ReservationService.java
@@ -59,7 +59,11 @@ public class ReservationService {
                 throw new BusinessException(FORBIDDEN_ACCESS);
             }
 
-            Slice<Reservation> slice = reservationRepository.findByShopIdWithFilterAndCursor(
+//            Slice<Reservation> slice = reservationRepository.findByShopIdWithFilterAndCursor(
+//                shopId, status, cursor, pageable
+//            );
+
+            Slice<Reservation> slice = reservationRepository.findByShopIdWithFilterAndCursorQdsl(
                 shopId, status, cursor, pageable
             );
 
@@ -75,7 +79,11 @@ public class ReservationService {
             .map(Shop::getId)
             .toList();
 
-        Slice<Reservation> slice = reservationRepository.findByShopIdsWithFilterAndCursor(
+//        Slice<Reservation> slice = reservationRepository.findByShopIdsWithFilterAndCursor(
+//            shopIds, status, cursor, pageable
+//        );
+
+        Slice<Reservation> slice = reservationRepository.findByShopIdsWithFilterAndCursorQdsl(
             shopIds, status, cursor, pageable
         );
 
@@ -97,7 +105,11 @@ public class ReservationService {
 
     @Transactional(readOnly = true)
     public MyReservationPageResponse findMyReservationPage(Long userId, Long cursor, int size) {
-        Slice<MyReservationResponse> reservations = reservationRepository.findByUserIdAndCursor(
+//        Slice<MyReservationResponse> reservations = reservationRepository.findByUserIdAndCursor(
+//            userId, cursor,
+//            PageRequest.of(0, size));
+
+        Slice<MyReservationResponse> reservations = reservationRepository.findByUserIdAndCursorQdsl(
             userId, cursor,
             PageRequest.of(0, size));
 
@@ -154,6 +166,8 @@ public class ReservationService {
     @Transactional
     public void cancelReservation(Long reservationId, Long userId) {
         Reservation reservation = getReservationById(reservationId);
+        log.info("[CANCEL] reservationId={}, reservationUserId={}, callerUserId={}",
+            reservationId, reservation.getUser().getId(), userId);
         User user = userService.getUserById(userId);
 
         // 예약한 본인인지 확인
@@ -209,8 +223,14 @@ public class ReservationService {
     public int terminateExpiredReservations() {
         LocalDateTime threshold = LocalDateTime.now().minusDays(1);
 
+//        List<Reservation> toTerminate = reservationRepository
+//            .findAllByStatusAndReservedAtBefore(
+//                ReservationStatus.CONFIRMED,
+//                threshold
+//            );
+
         List<Reservation> toTerminate = reservationRepository
-            .findAllByStatusAndReservedAtBefore(
+            .findAllByStatusAndReservedAtBeforeQdsl(
                 ReservationStatus.CONFIRMED,
                 threshold
             );

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepository.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepository.java
@@ -12,7 +12,7 @@ import shop.matjalalzz.reservation.dto.MyReservationResponse;
 import shop.matjalalzz.reservation.entity.Reservation;
 import shop.matjalalzz.reservation.entity.ReservationStatus;
 
-public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+public interface ReservationRepository extends JpaRepository<Reservation, Long>, ReservationRepositoryCustom {
 
     @Query("""
         SELECT r FROM Reservation r

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepository.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import shop.matjalalzz.reservation.dto.MyReservationResponse;
+import shop.matjalalzz.reservation.dto.MyReservationView;
 import shop.matjalalzz.reservation.dto.ReservationSummaryDto;
 import shop.matjalalzz.reservation.entity.Reservation;
 import shop.matjalalzz.reservation.entity.ReservationStatus;
@@ -60,9 +61,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
 
     // 회원이 진행한 예약과 회원이 속한 파티가 진행한 예약을 조회
     @Query("""
-        select new shop.matjalalzz.reservation.dto.MyReservationResponse(
-                r.id, s.shopName, u.name, r.reservedAt, r.headCount, r.reservationFee, r.status
-        )
+        SELECT r.id as reservationId, s.shopName as shopName, u.name as name,
+               r.reservedAt as reservedAt, r.headCount as headCount,
+               r.reservationFee as reservationFee, r.status as status
         from Reservation r
             join r.shop  s
             join r.user  u
@@ -77,7 +78,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
             )
         order by r.id desc
         """)
-    Slice<MyReservationResponse> findByUserIdAndCursor(
+    Slice<MyReservationView> findByUserIdAndCursor(
         @Param("userId") Long userId,
         @Param("cursor") Long cursor,
         Pageable pageable);

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepositoryCustom.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepositoryCustom.java
@@ -1,0 +1,17 @@
+package shop.matjalalzz.reservation.dao;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import shop.matjalalzz.reservation.dto.MyReservationResponse;
+import shop.matjalalzz.reservation.entity.Reservation;
+import shop.matjalalzz.reservation.entity.ReservationStatus;
+
+public interface ReservationRepositoryCustom {
+    Slice<Reservation> findByShopIdWithFilterAndCursorQdsl(Long shopId, ReservationStatus status, Long cursor, Pageable pageable);
+    Slice<Reservation> findByShopIdsWithFilterAndCursorQdsl(List<Long> shopIds, ReservationStatus status, Long cursor, Pageable pageable);
+    Slice<MyReservationResponse> findByUserIdAndCursorQdsl(Long userId, Long cursor, Pageable pageable);
+    List<Reservation> findAllByStatusAndReservedAtBeforeQdsl(ReservationStatus status, LocalDateTime threshold);
+
+}

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepositoryCustom.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepositoryCustom.java
@@ -4,14 +4,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import shop.matjalalzz.reservation.dto.MyReservationResponse;
 import shop.matjalalzz.reservation.entity.Reservation;
 import shop.matjalalzz.reservation.entity.ReservationStatus;
 
 public interface ReservationRepositoryCustom {
     Slice<Reservation> findByShopIdWithFilterAndCursorQdsl(Long shopId, ReservationStatus status, Long cursor, Pageable pageable);
     Slice<Reservation> findByShopIdsWithFilterAndCursorQdsl(List<Long> shopIds, ReservationStatus status, Long cursor, Pageable pageable);
-    Slice<MyReservationResponse> findByUserIdAndCursorQdsl(Long userId, Long cursor, Pageable pageable);
     List<Reservation> findAllByStatusAndReservedAtBeforeQdsl(ReservationStatus status, LocalDateTime threshold);
 
 }

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepositoryImpl.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepositoryImpl.java
@@ -1,0 +1,88 @@
+package shop.matjalalzz.reservation.dao;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
+import org.springframework.stereotype.Repository;
+import shop.matjalalzz.reservation.dto.MyReservationResponse;
+import shop.matjalalzz.reservation.entity.QReservation;
+import shop.matjalalzz.reservation.entity.Reservation;
+import shop.matjalalzz.reservation.entity.ReservationStatus;
+import shop.matjalalzz.shop.entity.QShop;
+
+@Repository
+@RequiredArgsConstructor
+public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
+
+    private final JPAQueryFactory query;
+    private static final QReservation r = QReservation.reservation;
+    private static final QShop s = QShop.shop;
+
+    @Override
+    public Slice<Reservation> findByShopIdWithFilterAndCursorQdsl(Long shopId, ReservationStatus status, Long cursor, Pageable pageable) {
+        var list = query.selectFrom(r)
+            .where(r.shop.id.eq(shopId), eqStatus(status), ltCursor(cursor))
+            .orderBy(r.id.desc())
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+        return toSlice(list, pageable.getPageSize());
+    }
+
+    @Override
+    public Slice<Reservation> findByShopIdsWithFilterAndCursorQdsl(List<Long> shopIds, ReservationStatus status, Long cursor, Pageable pageable) {
+        if (shopIds == null || shopIds.isEmpty()) return new SliceImpl<>(List.of(), pageable, false);
+        var list = query.selectFrom(r)
+            .where(r.shop.id.in(shopIds), eqStatus(status), ltCursor(cursor))
+            .orderBy(r.id.desc())
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+        return toSlice(list, pageable.getPageSize());
+    }
+
+    @Override
+    public Slice<MyReservationResponse> findByUserIdAndCursorQdsl(Long userId, Long cursor, Pageable pageable) {
+        var list = query
+            .select(Projections.constructor(MyReservationResponse.class,
+                r.id,
+                s.shopName,
+                r.reservedAt,
+                r.headCount,
+                r.reservationFee,
+                r.status
+            ))
+            .from(r)
+            .join(r.shop, s)
+            .where(r.user.id.eq(userId), ltCursor(cursor))
+            .orderBy(r.id.desc())
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+        boolean hasNext = list.size() > pageable.getPageSize();
+        if (hasNext) list = list.subList(0, pageable.getPageSize());
+        return new SliceImpl<>(list, pageable, hasNext);
+    }
+
+    @Override
+    public List<Reservation> findAllByStatusAndReservedAtBeforeQdsl(ReservationStatus status, LocalDateTime threshold) {
+        return query.selectFrom(r)
+            .where(r.status.eq(status), r.reservedAt.loe(threshold))
+            .fetch();
+    }
+
+    /* helpers */
+    private BooleanExpression eqStatus(ReservationStatus st) { return st == null ? null : r.status.eq(st); }
+    private BooleanExpression ltCursor(Long cursor) { return cursor == null ? null : r.id.lt(cursor); }
+    private static <T> Slice<T> toSlice(List<T> rows, int size) {
+        boolean hasNext = rows.size() > size;
+        if (hasNext) rows = rows.subList(0, size);
+        return new SliceImpl<>(rows, PageRequest.of(0, size), hasNext);
+    }
+}
+

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepositoryImpl.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/dao/ReservationRepositoryImpl.java
@@ -1,6 +1,5 @@
 package shop.matjalalzz.reservation.dao;
 
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
@@ -10,14 +9,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
 import org.springframework.stereotype.Repository;
-import shop.matjalalzz.reservation.dto.MyReservationResponse;
 import shop.matjalalzz.reservation.entity.QReservation;
 import shop.matjalalzz.reservation.entity.Reservation;
 import shop.matjalalzz.reservation.entity.ReservationStatus;
-import shop.matjalalzz.shop.entity.QShop;
-import shop.matjalalzz.user.entity.QUser;
 
 @Repository
 @RequiredArgsConstructor
@@ -25,8 +20,6 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
 
     private final JPAQueryFactory query;
     private static final QReservation r = QReservation.reservation;
-    private static final QShop s = QShop.shop;
-    private static final QUser u = QUser.user;
 
     @Override
     public Slice<Reservation> findByShopIdWithFilterAndCursorQdsl(Long shopId, ReservationStatus status, Long cursor, Pageable pageable) {
@@ -47,30 +40,6 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
             .limit(pageable.getPageSize() + 1)
             .fetch();
         return toSlice(list, pageable.getPageSize());
-    }
-
-    @Override
-    public Slice<MyReservationResponse> findByUserIdAndCursorQdsl(Long userId, Long cursor, Pageable pageable) {
-        var list = query
-            .select(Projections.constructor(MyReservationResponse.class,
-                r.id,
-                s.shopName,
-                u.name,
-                r.reservedAt,
-                r.headCount,
-                r.reservationFee,
-                r.status
-            ))
-            .from(r)
-            .join(r.user, u)
-            .join(r.shop, s)
-            .where(r.user.id.eq(userId), ltCursor(cursor))
-            .orderBy(r.id.desc())
-            .limit(pageable.getPageSize() + 1)
-            .fetch();
-        boolean hasNext = list.size() > pageable.getPageSize();
-        if (hasNext) list = list.subList(0, pageable.getPageSize());
-        return new SliceImpl<>(list, pageable, hasNext);
     }
 
     @Override

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/dto/MyReservationView.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/dto/MyReservationView.java
@@ -1,0 +1,14 @@
+package shop.matjalalzz.reservation.dto;
+
+import java.time.LocalDateTime;
+import shop.matjalalzz.reservation.entity.ReservationStatus;
+
+public interface MyReservationView {
+    long getReservationId();
+    String getShopName();
+    String getName();
+    LocalDateTime getReservedAt();
+    int getHeadCount();
+    int getReservationFee();
+    ReservationStatus getStatus();
+}

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/dto/ReservationSummaryDto.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/dto/ReservationSummaryDto.java
@@ -1,0 +1,15 @@
+package shop.matjalalzz.reservation.dto;
+
+import java.time.LocalDateTime;
+import shop.matjalalzz.reservation.entity.ReservationStatus;
+
+public record ReservationSummaryDto(
+    Long reservationId,
+    String shopName,
+    LocalDateTime reservedAt,
+    int headCount,
+    String phoneNumber,
+    ReservationStatus status
+) {
+
+}

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/mapper/ReservationMapper.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/mapper/ReservationMapper.java
@@ -12,6 +12,7 @@ import shop.matjalalzz.reservation.dto.MyReservationPageResponse;
 import shop.matjalalzz.reservation.dto.MyReservationResponse;
 import shop.matjalalzz.reservation.dto.ReservationListResponse;
 import shop.matjalalzz.reservation.dto.ReservationListResponse.ReservationContent;
+import shop.matjalalzz.reservation.dto.ReservationSummaryDto;
 import shop.matjalalzz.reservation.entity.Reservation;
 import shop.matjalalzz.reservation.entity.ReservationStatus;
 import shop.matjalalzz.shop.entity.Shop;
@@ -85,5 +86,20 @@ public class ReservationMapper {
             .nextCursor(nextCursor)
             .content(reservations.getContent())
             .build();
+    }
+
+    public static List<ReservationContent> toReservationProjectionContent(List<ReservationSummaryDto> rows) {
+        var out = new java.util.ArrayList<ReservationContent>(rows.size());
+        for (var r : rows) {
+            out.add(ReservationContent.builder()
+                .reservationId(r.reservationId())
+                .shopName(r.shopName())
+                .reservedAt(r.reservedAt())
+                .headCount(r.headCount())
+                .phoneNumber(r.phoneNumber())
+                .status(r.status())
+                .build());
+        }
+        return out;
     }
 }

--- a/matjalalzz/src/main/java/shop/matjalalzz/reservation/mapper/ReservationMapper.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/reservation/mapper/ReservationMapper.java
@@ -10,11 +10,13 @@ import shop.matjalalzz.reservation.dto.CreateReservationRequest;
 import shop.matjalalzz.reservation.dto.CreateReservationResponse;
 import shop.matjalalzz.reservation.dto.MyReservationPageResponse;
 import shop.matjalalzz.reservation.dto.MyReservationResponse;
+import shop.matjalalzz.reservation.dto.MyReservationView;
 import shop.matjalalzz.reservation.dto.ReservationListResponse;
 import shop.matjalalzz.reservation.dto.ReservationListResponse.ReservationContent;
 import shop.matjalalzz.reservation.dto.ReservationSummaryDto;
 import shop.matjalalzz.reservation.entity.Reservation;
 import shop.matjalalzz.reservation.entity.ReservationStatus;
+import shop.matjalalzz.review.dto.MyReviewResponse;
 import shop.matjalalzz.shop.entity.Shop;
 import shop.matjalalzz.user.entity.User;
 
@@ -78,6 +80,18 @@ public class ReservationMapper {
                 .status(res.getStatus())
                 .build())
             .toList();
+    }
+
+    public static MyReservationResponse toMyReservationResponse(MyReservationView view) {
+        return MyReservationResponse.builder()
+            .reservationId(view.getReservationId())
+            .shopName(view.getShopName())
+            .name(view.getName())
+            .reservationFee(view.getReservationFee())
+            .headCount(view.getHeadCount())
+            .reservedAt(view.getReservedAt())
+            .status(view.getStatus())
+            .build();
     }
 
     public static MyReservationPageResponse toMyReservationPageResponse(Long nextCursor,

--- a/matjalalzz/src/main/java/shop/matjalalzz/review/dao/ReviewRepository.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/review/dao/ReviewRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import shop.matjalalzz.review.dto.MyReviewResponse;
+import shop.matjalalzz.review.dto.MyReviewView;
 import shop.matjalalzz.review.entity.Review;
 import shop.matjalalzz.shop.entity.Shop;
 
@@ -16,19 +16,17 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         Pageable pageable);
 
     @Query("""
-        SELECT new shop.matjalalzz.review.dto.MyReviewResponse(
-            r.id, s.shopName, r.rating, r.content, r.createdAt, null
-        )
+        SELECT r.id AS reviewId, s.shopName AS shopName, r.rating AS rating, r.content AS content,
+               r.createdAt AS createdAt
         FROM Review r
         JOIN r.shop s
         WHERE r.writer.id = :userId
-            AND (:cursor = 0 OR r.id < :cursor)
+            AND (:cursor IS NULL OR r.id < :cursor)
         ORDER BY r.id DESC
         """)
-    Slice<MyReviewResponse> findByUserIdAndCursor(@Param("userId") Long userId,
+    Slice<MyReviewView> findByUserIdAndCursor(@Param("userId") Long userId,
         @Param("cursor") Long cursor,
         Pageable pageable);
-
 
     @Query("select count(r) from Review r where r.shop.id =:shopId")
     int findReviewCount(@Param("shopId") Long shopId);

--- a/matjalalzz/src/main/java/shop/matjalalzz/review/dto/MyReviewView.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/review/dto/MyReviewView.java
@@ -1,0 +1,11 @@
+package shop.matjalalzz.review.dto;
+
+import java.time.LocalDateTime;
+
+public interface MyReviewView {
+    long getReviewId();
+    String getShopName();
+    double getRating();
+    String getContent();
+    LocalDateTime getCreatedAt();
+}

--- a/matjalalzz/src/main/java/shop/matjalalzz/review/mapper/ReviewMapper.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/review/mapper/ReviewMapper.java
@@ -1,12 +1,14 @@
 package shop.matjalalzz.review.mapper;
 
 import java.util.List;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Slice;
 import shop.matjalalzz.reservation.entity.Reservation;
 import shop.matjalalzz.review.dto.MyReviewPageResponse;
 import shop.matjalalzz.review.dto.MyReviewResponse;
+import shop.matjalalzz.review.dto.MyReviewView;
 import shop.matjalalzz.review.dto.ReviewCreateRequest;
 import shop.matjalalzz.review.dto.ReviewPageResponse;
 import shop.matjalalzz.review.dto.ReviewResponse;
@@ -36,12 +38,26 @@ public class ReviewMapper {
             .build();
     }
 
+    public static MyReviewResponse toMyReviewResponse(MyReviewView view, List<String> reviewImages) {
+        return MyReviewResponse.builder()
+            .reviewId(view.getReviewId())
+            .shopName(view.getShopName())
+            .rating(view.getRating())
+            .content(view.getContent())
+            .createdAt(view.getCreatedAt())
+            .images(reviewImages)
+            .build();
+    }
+
     public static MyReviewPageResponse toMyReviewPageResponse(Long nextCursor,
-        Slice<MyReviewResponse> reviews) {
+        List<MyReviewView> reviews, Map<Long, List<String>> reviewImageMap) {
+        List<MyReviewResponse> responses = reviews.stream()
+            .map(v -> toMyReviewResponse(v, reviewImageMap.get(v.getReviewId())))
+            .toList();
 
         return MyReviewPageResponse.builder()
             .nextCursor(nextCursor)
-            .content(reviews.getContent())
+            .content(responses)
             .build();
     }
 

--- a/matjalalzz/src/main/java/shop/matjalalzz/user/dao/UserRepository.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/user/dao/UserRepository.java
@@ -2,11 +2,22 @@ package shop.matjalalzz.user.dao;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import shop.matjalalzz.user.dto.LoginInfoDto;
 import shop.matjalalzz.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByOauthId(String oauthId);
-
     Optional<User> findByEmail(String email);
+
+    @Query("""
+        SELECT new shop.matjalalzz.user.dto.LoginInfoDto(
+                u.id, u.password, u.role, u.email, rt.refreshToken)
+        FROM User u
+            LEFT JOIN RefreshToken rt on u.id = rt.user.id
+        WHERE u.email = :email
+        """)
+    Optional<LoginInfoDto> findByEmailForLogin(@Param("email") String email);
 }

--- a/matjalalzz/src/main/java/shop/matjalalzz/user/dto/LoginInfoDto.java
+++ b/matjalalzz/src/main/java/shop/matjalalzz/user/dto/LoginInfoDto.java
@@ -1,0 +1,8 @@
+package shop.matjalalzz.user.dto;
+
+import shop.matjalalzz.user.entity.enums.Role;
+
+public record LoginInfoDto(
+    Long userId, String password, Role role, String email, String refreshToken) {
+
+}

--- a/matjalalzz/src/main/resources/application.yml
+++ b/matjalalzz/src/main/resources/application.yml
@@ -104,7 +104,15 @@ toss:
   client-key: ${TOSS_CLIENT_KEY}
 
 logging:
-  root: INFO
+  level:
+    root: INFO
+    shop.matjalalzz.global.aop: INFO      # [PERF]
+    shop.matjalalzz.global.config: INFO   # [SQL]
+    net.ttddyy: INFO
+    shop.matjalalzz.reservation.api: DEBUG
+    shop.matjalalzz.reservation.app: DEBUG
+
+
 server:
   port: ${SERVER_PORT}
 


### PR DESCRIPTION
## 📌 관련 이슈
- #148 

## 💡 구현 내용 요약
- 마이페이지 조회, 토큰 관련 api 성능 체크 후 개선 및 리팩토링

## ✅ 작업 상세 내용
- accessToken 재발급 성능 개선
- 내 리뷰 조회 api에 이미지 조회 기능 추가
- 로그인 시, 항상 리프레시 토큰을 재발급하도록 로직 수정

<html>
<body>
<!--StartFragment--><h1>1. access token 재발급</h1>
<ul>
<li>
<p>문제 상황</p>
<ul>
<li>token과 회원 정보를 두 개의 쿼리로 조회해 옴</li>
<li>회원의 role과 email만 필요한데, entity 전부 조회</li>
</ul>
<pre><code class="language-java">RefreshToken token = refreshTokenRepository.findByUserIdWithUser(userId)
            .orElseThrow(() -&gt; new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN));
User user = token.getUser();
</code></pre>
</li>
<li>
<p>해결</p>
<ul>
<li>인터페이스 프로젝션 방식으로 필요한 칼럼만 조회</li>
</ul>
<pre><code class="language-java">AuthUserInfoDto info = refreshTokenRepository.findByUserIdWithUser(userId)
            .orElseThrow(() -&gt; new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN));
</code></pre>
</li>
<li>
<p>성능 비교 (가상 유저 = 1000)</p>
</li>
</ul>

  | 변경 전 | 변경 후
-- | -- | --
TPS | 1,194.8 | 1,643.5
MTT | 791.7 | 859.8

<ul>
<li>변경 전</li>
</ul>
<p><img width="968" height="325" alt="image" src="https://github.com/user-attachments/assets/1f4983b4-1579-4ac7-9b69-c5cacf3596ad" /></p>
<ul>
<li>변경 후</li>
</ul>
<p><img width="967" height="326" alt="image1" src="https://github.com/user-attachments/assets/515bd62a-b572-42be-af1a-f6000dd9b55a" /></p>
<h1>2. 내 리뷰 조회</h1>
<ul>
<li>
<p>문제 상황</p>
<ul>
<li>리뷰의 이미지 조회를 생략하고 있었음</li>
</ul>
<pre><code class="language-java">    @Query(&quot;&quot;&quot;
        SELECT new shop.matjalalzz.review.dto.MyReviewResponse(
            r.id, s.shopName, r.rating, r.content, r.createdAt, null
        )
        FROM Review r
        JOIN r.shop s
        WHERE r.writer.id = :userId
            AND (:cursor = 0 OR r.id &lt; :cursor)
        ORDER BY r.id DESC
        &quot;&quot;&quot;)
    Slice&lt;MyReviewResponse&gt; findByUserIdAndCursor(@Param(&quot;userId&quot;) Long userId,
        @Param(&quot;cursor&quot;) Long cursor,
        Pageable pageable);
</code></pre>
</li>
<li>
<p>해결</p>
<ul>
<li>쿼리 두 번으로 이미지까지 조회하도록 수정</li>
</ul>
<pre><code class="language-java">    @Query(&quot;&quot;&quot;
        SELECT r.id AS reviewId, s.shopName AS shopName, r.rating AS rating, r.content AS content,
               r.createdAt AS createdAt
        FROM Review r
        JOIN r.shop s
        WHERE r.writer.id = :userId
            AND (:cursor IS NULL OR r.id &lt; :cursor)
        ORDER BY r.id DESC
        &quot;&quot;&quot;)
    Slice&lt;MyReviewView&gt; findByUserIdAndCursor(@Param(&quot;userId&quot;) Long userId,
        @Param(&quot;cursor&quot;) Long cursor,
        Pageable pageable);
</code></pre>
<pre><code class="language-java">		@Query(&quot;&quot;&quot;
        SELECT i.reviewId AS reviewId, i.s3Key AS s3Key
        FROM Image i
        WHERE i.reviewId in :reviewIds
        ORDER BY i.reviewId ASC, i.imageIndex ASC
        &quot;&quot;&quot;)
    List&lt;ReviewImageView&gt; findImageKeyByReviewIds(@Param(&quot;reviewIds&quot;) List&lt;Long&gt; reviewIds);
</code></pre>
</li>
</ul>
<!-- notionvc: af28e8dc-90e5-46bf-b3cb-2198067da335 --><!--EndFragment-->
</body>
</html>

## 🧪 check list
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함
- [x] merge할 브랜치의 위치를 확인함

## 📎 기타 참고 사항
- 나머지 마이페이지 관련 조회는 기존 JPQL 방식 유지 (인터페이스 프로젝션)
